### PR TITLE
Store and send CSRF tokens to the API

### DIFF
--- a/public/jsx/views/login.jsx
+++ b/public/jsx/views/login.jsx
@@ -29,9 +29,17 @@ module.exports = React.createClass({
       method: 'post',
       url: '/api/auth/sign-in/',
       context: this,
-    }).then(function() {
+    }).then(function(data) {
       if (this.isMounted()) {
         this.setState({'is_logged_in': true}); // eslint-disable-line
+
+        console.log('setting CSRF token for subsequent requests:', data.csrf_token);
+        $.ajaxSetup({
+          headers: {
+            "X-CSRFToken": data.csrf_token,
+          },
+        });
+
         this.transitionTo('card-listing');
       }
     }).fail(function() {


### PR DESCRIPTION
Part of https://github.com/mozilla/payments-service/issues/46

I can't think of an easy way to test this. Any ideas?

Going forward, I think we could make an API abstraction (perhaps around fetch, see https://github.com/mozilla/payments-ui/issues/84). If we design the abstraction with testability in mind we could stub it out in tests so that components are fed mock return data. This would allow the tests to make assertions about what components do with the data.