### PR TITLE
Add csslint (fixes #8)

### DIFF
--- a/.csslintrc
+++ b/.csslintrc
@@ -1,0 +1,18 @@
+{
+    "adjoining-classes": false,
+    "box-model": false,
+    "box-sizing": false,
+    "bulletproof-font-face": false,
+    "compatible-vendor-prefixes": false,
+    "duplicate-properties": 2,
+    "font-faces": false,
+    "font-sizes": false,
+    "ids": false,
+    "important": false,
+    "outline-none": false,
+    "regex-selectors": false,
+    "unique-headings": false,
+    "universal-selector": false,
+    "unqualified-attributes": false,
+    "zero-units": 2
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,5 +39,5 @@ module.exports = function(grunt) {
                      ['sass', 'webpack-dev-server:start', 'watch:sass']);
   grunt.registerTask('start', ['sass', 'webpack:dev', 'watch:sass']);
   grunt.registerTask('build', ['clean:dist', 'sass', 'webpack']);
-  grunt.registerTask('test', ['karma:run', 'eslint']);
+  grunt.registerTask('test', ['karma:run', 'eslint', 'csslint:lax']);
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "grunt": "0.4.5",
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-copy": "0.8.0",
+    "grunt-contrib-csslint": "0.4.0",
     "grunt-contrib-watch": "0.6.1",
     "grunt-devserver": "0.6.0",
     "grunt-eslint": "16.0.0",

--- a/public/scss/_base.scss
+++ b/public/scss/_base.scss
@@ -24,7 +24,7 @@ a {
 
   .accepted {
     @include header-font();
-    font-size: 1.75em;
+    font-size: $large-font;
     font-weight: 200;
     padding: 20px 0;
   }
@@ -93,8 +93,8 @@ main {
     & label {
       border: 1px solid transparent;
       display: block;
-      font-size: 18px;
-      font-weight: bold;
+      font-size: $medium-font;
+      font-weight: 700;
       padding: 1em 15px 1em 60px;
       position: relative;
       text-align: right;

--- a/public/scss/_buttons.scss
+++ b/public/scss/_buttons.scss
@@ -25,7 +25,7 @@ button {
 
   @include respond-to('small') {
     border-radius: $small-border-radius;
-    font-size: $medium-font + $media-adjustment;
+    font-size: $medium-font;
     padding: 8px 0;
   }
 

--- a/public/scss/_forms.scss
+++ b/public/scss/_forms.scss
@@ -52,7 +52,7 @@ input {
 
   @include respond-to('small') {
     border-radius: $small-border-radius;
-    font-size: $base-font + $media-adjustment;
+    font-size: $base-font;
     height: 40px;
   }
 

--- a/public/scss/_product.scss
+++ b/public/scss/_product.scss
@@ -5,9 +5,9 @@
 
   .title {
     font-size: $medium-font;
-    font-weight: normal;
+    font-weight: 400;
     padding-bottom: 0.35em;
-    margin: 0em;
+    margin: 0;
   }
 
   .price {

--- a/public/scss/_tooltip.scss
+++ b/public/scss/_tooltip.scss
@@ -3,7 +3,7 @@
   transition: 0.1s opacity $short-transition;
   display: block;
   color: #fff;
-  background: #F91200;
+  background: $error-background-color;
   padding: 0.5em 0.75em 0.7em;
   z-index: 10;
   position: absolute;
@@ -17,7 +17,7 @@
     // Dashed fixes anti-aliasing in ff.
     border-left: 1em dashed transparent;
     border-right: 1em dashed transparent;
-    border-top: 1em solid #F91200;
+    border-top: 1em solid $error-background-color;
     border-bottom: 0;
     top: 100%;
     left: 0.5em;

--- a/public/scss/_tooltip.scss
+++ b/public/scss/_tooltip.scss
@@ -6,7 +6,6 @@
   background: #F91200;
   padding: 0.5em 0.75em 0.7em;
   z-index: 10;
-  top: -0.5em;
   position: absolute;
   white-space: nowrap;
   top: -2.1em;

--- a/public/scss/_typography.scss
+++ b/public/scss/_typography.scss
@@ -34,4 +34,3 @@ h2 { font-size: 140%; }
 h3 { font-size: 130%; }
 h4 { font-size: 120%; }
 h5 { font-size: 110%; }
-h6 { font-size: 100%; }

--- a/public/scss/inc/mixins.scss
+++ b/public/scss/inc/mixins.scss
@@ -38,7 +38,6 @@
     font-family: "#{$family}";
     src: url($filepath + ".eot");
     src: local($local-name),
-         url($filepath + ".eot?#iefix") format('embedded-opentype'),
          url($filepath + ".woff") format('woff'),
          url($filepath + ".ttf")  format('truetype');
     font-weight: unquote($font-weight);
@@ -57,6 +56,6 @@
   (-webkit-min-device-pixel-ratio: 1.3),
   (min-device-pixel-ratio: 1.3),
   (min-resolution: 1.3dppx) {
-    background-image: image-url("#{$filename}@2x.#{$extension}");
+    background-image: url("../img/#{$filename}@2x.#{$extension}");
   }
 }

--- a/tasks/csslint.js
+++ b/tasks/csslint.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  lax: {
+    options: {
+      csslintrc: '.csslintrc'
+    },
+    src: ['public/dist/main.css']
+  },
+  strict: {
+    options: {
+      'adjoining-classes': false,
+      'box-sizing': false,
+      'bulletproof-font-face': false,
+    },
+    src: ['public/dist/main.css']
+  },
+};


### PR DESCRIPTION
Quite a lot of this is noise so I've trimmed out a lot of that. Because rules are a bit all or nothing (e.g. when you opt-out of a rule you kill it for everything unlike eslint/jshint etc) I've added two modes. The lax mode (run with `grunt csslint:lax`) is what's run as part of tests. This has some errors enforced so that travis will fail if we have duped props. We should probably fix anything that starts popping up here or update the configuration.

The strict mode (run with `grunt csslint:strict`) is to see all the things csslint doesn't like which will be worth running every once in a while to see if we can clean some it up if relevant. I've excluded things that we 100% don't care about from this in the grunt rules.

Whilst ignoring a lot of the rules makes this feel a bit redundant, running csslint did catch a couple of silly things so on that basis it *does* add value.