### PR TITLE
Move app-error styling (fixes #193)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,7 +18,7 @@ module.exports = function(grunt) {
   grunt.registerTask('build-styleguide', ['sass', 'webpack:styleguide', 'cog']);
   grunt.registerTask('publish-styleguide',
                      ['build-styleguide', 'gh-pages:styleguide']);
-   grunt.registerTask('styleguide',
+  grunt.registerTask('styleguide',
                      ['build-styleguide', 'devserver']);
 
   grunt.registerTask('publish-docker', function() {

--- a/public/js/components/error.jsx
+++ b/public/js/components/error.jsx
@@ -18,7 +18,9 @@ module.exports = React.createClass({
     console.log('rendering app error:', this.props.error);
     return (
       <div className="app-error">
-        {gettext('Internal error. Please try again later.')}
+        <p className="msg">
+          {gettext('Internal error. Please try again later.')}
+        </p>
       </div>
     );
   },

--- a/public/scss/_app-error.scss
+++ b/public/scss/_app-error.scss
@@ -1,0 +1,19 @@
+.app-error {
+    background: rgba(255,255,255,0.8);
+    bottom: 0;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: 10;
+
+    .msg {
+        @include header-font();
+        color: $error-text-color;
+        margin: 0;
+        position: relative;
+        text-align: center;
+        top: 50%;
+        transform: translateY(-50%);
+    }
+}

--- a/public/scss/_base.scss
+++ b/public/scss/_base.scss
@@ -96,10 +96,3 @@ main {
       text-align: right;
   }
 }
-
-.app-error {
-    @include header-font();
-    color: $error-text-color;
-    margin-top: 50%;
-    text-align: center;
-}

--- a/public/scss/inc/mixins.scss
+++ b/public/scss/inc/mixins.scss
@@ -59,3 +59,11 @@
     background-image: url("#{$image-path}#{$filename}@2x.#{$extension}");
   }
 }
+
+@mixin visuallyhidden() {
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  height: 1px; width: 1px;
+  margin: -1px; padding: 0; border: 0;
+}

--- a/public/scss/main.scss
+++ b/public/scss/main.scss
@@ -13,4 +13,5 @@
 @import '_utils';
 @import '_spinner';
 @import '_tooltip';
+@import '_app-error';
 @import '_management';

--- a/styleguide/jsx/app-error.jsx
+++ b/styleguide/jsx/app-error.jsx
@@ -1,0 +1,7 @@
+'use strict';
+
+var React = require('react');
+var AppError = require('components/error');
+var CardForm = require('components/card-form');
+React.render(<CardForm />, document.getElementById('view'));
+React.render(<AppError />, document.getElementById('error'));

--- a/styleguide/pages/app-error.md
+++ b/styleguide/pages/app-error.md
@@ -1,0 +1,12 @@
+# App Error
+
+This is the app error component.
+
+```iframe
+sourcecodeSelector: '#error'
+dynamicSource: true
+title: App Error
+renderer: nunjucks
+template: jsx.html
+bundle: app-error
+```

--- a/styleguide/templates/base-styleguide.html
+++ b/styleguide/templates/base-styleguide.html
@@ -9,6 +9,8 @@
   </head>
   <body>
     <main>
+      <div id="error">
+      </div>
       <div id="view">
         {% block page %}{% endblock %}
       </div>

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -21,6 +21,7 @@ module.exports = {
   styleguide: {
     entry: {
       // Explicit entries for the styleguide.
+      'app-error': './styleguide/jsx/app-error',
       'card-form': './styleguide/jsx/card-form',
       'spinner': './styleguide/jsx/spinner',
     },


### PR DESCRIPTION
This still needs to have the app error component updated to do an overlay as it's not currently implemented in this way afaict. But this at least means the styles are ready for that.

Added to the styleguide to demonstrate what it looks like with something underneath.

<img alt="payments_ui_styleguide___app_error" src="https://cloud.githubusercontent.com/assets/1514/8669960/a95ad3f2-2a10-11e5-937f-59fd821b45e4.png">
