### PR TITLE
Fix up API handling for adding a pay method

### DIFF
--- a/public/js/actions/pay-methods.js
+++ b/public/js/actions/pay-methods.js
@@ -43,16 +43,16 @@ export function addCreditCard(braintreeToken, creditCard, jquery=$,
       } else {
         jquery.ajax({
           data: {
-            pay_method_nonce: nonce,
+            nonce: nonce,
           },
-          url: '/api/braintree/mozilla/paymethod/',
+          url: '/api/braintree/paymethod/',
           method: 'post',
           dataType: 'json',
         }).then(data => {
-          console.log('Successfully added a card');
+          console.log('Successfully added a pay method. API Result:', data);
           dispatch({
             type: actionTypes.GOT_PAY_METHODS,
-            payMethods: data,
+            payMethods: data.payment_methods,
           });
         }).fail($xhr => {
           dispatch({

--- a/public/js/apps/management/app.jsx
+++ b/public/js/apps/management/app.jsx
@@ -43,6 +43,7 @@ export default class ManagementApp extends Component {
   }
 
   renderChild(connector) {
+    console.log('rendering management app at tab:', connector.management.tab);
     var qs = parseQuery(this.props.window.location.href);
     var accessToken = qs.access_token;
     var boundMgmtActions = bindActionCreators(mgmtActions,


### PR DESCRIPTION
These changes are related to https://github.com/mozilla/payments-service/pull/121

This gets the action and data flow working after submitting a new card. 

However, the app gets stuck on the Add Card modal. I thought about this a little but I think it's complicated to fix in the current app. I say we hold off until the tab design layout. 