### PR TITLE
Remove conditional around fetching subs (fixes #275)

### DIFF
--- a/public/js/views/management/subscriptions.jsx
+++ b/public/js/views/management/subscriptions.jsx
@@ -12,9 +12,7 @@ export default class Subscriptions extends Component {
   };
 
   componentDidMount() {
-    if (this.props.userSubscriptions === null) {
-      this.props.getUserSubscriptions();
-    }
+    this.props.getUserSubscriptions();
   }
 
   render() {

--- a/tests/views/test.subscriptions.jsx
+++ b/tests/views/test.subscriptions.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import TestUtils from 'react/lib/ReactTestUtils';
+
+import Subscriptions from 'views/management/subscriptions';
+
+
+describe('Subscriptions', function() {
+
+  var getUserSubsSpy = sinon.stub();
+
+  function mountView() {
+    return TestUtils.renderIntoDocument(
+      <Subscriptions getUserSubscriptions={getUserSubsSpy} />
+    );
+  }
+
+  it('should call getUserSubscriptions on mount', function() {
+    mountView();
+    assert.equal(getUserSubsSpy.called, true);
+  });
+
+});


### PR DESCRIPTION
This means we always fetch subs when clicking the nav for subscriptions.