### PR TITLE
Add drop-down via React (fixes #267)

### DIFF
--- a/public/js/components/card-drop-down.jsx
+++ b/public/js/components/card-drop-down.jsx
@@ -1,0 +1,110 @@
+import React, { Component, PropTypes } from 'react';
+import cx from 'classnames';
+
+import CardIcon from 'components/card-icon';
+import { gettext } from 'utils';
+
+const defaultSelectText = gettext('Please select');
+
+
+export default class CardDropDown extends Component {
+
+  static propTypes = {
+    cards: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number,
+        resource_uri: PropTypes.string,
+        truncated_id: PropTypes.string,
+        type_name: PropTypes.string,
+      })
+    ).isRequired,
+    cssModifier: PropTypes.string,
+    onCardChange: PropTypes.func.isRequired,
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      selectedText: defaultSelectText,
+      selectedCardType: null,
+      isFocused: false,
+    };
+  }
+
+  handleFocus = () => {
+    this.setState({isFocused: true});
+  }
+
+  handleBlur = () => {
+    this.setState({isFocused: false});
+  }
+
+  handleChange = e => {
+    if (this.props.onCardChange) {
+      this.props.onCardChange(e);
+    }
+    var selectedText;
+    var selectedNode = e.target.options[e.target.selectedIndex];
+    if (selectedNode) {
+
+      var selectedCardType = selectedNode.getAttribute('data-type');
+      if (selectedCardType) {
+        selectedText = selectedNode.firstChild.nodeValue.replace(
+          selectedCardType.toUpperCase(), '');
+      }
+    }
+    this.setState({
+      selectedText: selectedText || defaultSelectText,
+      selectedCardType: selectedCardType,
+    });
+  }
+
+  render() {
+    var cardData = this.props.cards;
+    var cardOptions = [];
+
+    cardOptions.push(<option value="">{defaultSelectText}</option>);
+
+    for (var i = 0; i < cardData.length; i += 1) {
+      var { selected, ...card } = cardData[i];
+      var optionText = card.type_name.toUpperCase() +
+        ' ●●●● ●●●● ●●●● ' + card.truncated_id;
+
+      cardOptions.push(
+        <option
+          data-type={card.type_name.toLowerCase()}
+          key={card.id}
+          selected={selected}
+          value={card.resource_uri}
+        >{optionText}</option>
+      );
+    }
+
+    var contentClasses = cx('content', {
+      'has-card': this.state.selectedCardType,
+    });
+
+    var proxySelectClasses = cx('proxy-select', {
+      'active': this.state.isFocused,
+    });
+
+    return (
+      <div className={proxySelectClasses}>
+        {this.state.selectedCardType ?
+         <CardIcon cardType={this.state.selectedCardType} /> :
+         null}
+        <span className={contentClasses} ariaHidden="true">
+          <span className="vh">{this.state.selectedCardType}</span>
+          {this.state.selectedText}
+        </span>
+        <select
+          onBlur={this.handleBlur}
+          onChange={this.handleChange}
+          onFocus={this.handleFocus}
+          onKeyUp={this.handleChange}>
+          {cardOptions}
+        </select>
+      </div>
+    );
+  }
+}

--- a/public/js/components/card-icon.jsx
+++ b/public/js/components/card-icon.jsx
@@ -25,7 +25,6 @@ export default class CardIcon extends Component {
     ]),
   }
 
-
   render() {
     // This is only displayed if a cardType is passed-in.
     var cardType = this.props.cardType;

--- a/public/js/views/management/pay-methods.jsx
+++ b/public/js/views/management/pay-methods.jsx
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import cx from 'classnames';
 
-import CardList from 'components/card-list';
+import CardDropdown from 'components/card-drop-down';
 
 import { gettext, isDisabled } from 'utils';
 
@@ -31,7 +31,7 @@ export default class PayMethods extends Component {
   renderChild() {
     if (this.props.payMethods && this.props.payMethods.length) {
       return (
-        <CardList cards={this.props.payMethods} />
+        <CardDropdown cards={this.props.payMethods} />
       );
     }
     return (<p className="no-results">

--- a/public/scss/_card-drop-down.scss
+++ b/public/scss/_card-drop-down.scss
@@ -1,0 +1,52 @@
+.proxy-select {
+
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  display: inline-block;
+  font-size: $medium-font;
+  margin-bottom: 1em;
+  padding: 0.5em 2em 0.5em 0.5em;
+  position: relative;
+  width: 100%;
+  max-width: 300px;
+
+  &.active {
+    border-color: $default-focus-color;
+    box-shadow: 0 0 1px 0 $default-focus-color;
+  }
+
+  .has-card {
+    padding-left: 50px;
+  }
+
+  .card-icon {
+    left: 8px;
+  }
+
+  &:after {
+    font-size: 12px;
+    color: #666;
+    content: '\25BC';
+    display: block;
+    right: 0.5em;
+    top: 50%;
+    transform: translateY(-50%);
+    position: absolute;
+  }
+
+  select {
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    appearance: none;
+    opacity: 0;
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 10;
+  }
+}

--- a/public/scss/management.scss
+++ b/public/scss/management.scss
@@ -20,5 +20,6 @@
 @import '_mgmt-nav-sprite.scss';
 @import '_card-list';
 @import '_pay-methods';
+@import '_card-drop-down.scss';
 
 @import '_management';

--- a/tests/helpers.jsx
+++ b/tests/helpers.jsx
@@ -98,6 +98,13 @@ export function findAllByTag(component, tag){
 }
 
 
+export function findAllNodesByTag(component, tag){
+  return findAllByTag(component, tag).map((item) => {
+    return React.findDOMNode(item);
+  });
+}
+
+
 export function getFluxContainer(store) {
   //
   // Get a container component to set context stubs so you can use it

--- a/tests/test.card-drop-down.jsx
+++ b/tests/test.card-drop-down.jsx
@@ -1,0 +1,109 @@
+import React, { findDOMNode } from 'react';
+import TestUtils from 'react/lib/ReactTestUtils';
+
+import CardDropDown from 'components/card-drop-down';
+
+import * as helpers from './helpers';
+
+
+describe('Card Dropdown', function() {
+
+  var cardListData = [{
+      'id': 1,
+      'resource_uri': '/braintree/mozilla/paymethod/1/',
+      'truncated_id': '4444',
+      'type_name': 'MasterCard',
+    }, {
+      'id': 2,
+      'resource_uri': '/braintree/mozilla/paymethod/2/',
+      'truncated_id': '1111',
+      'type_name': 'Visa',
+    }, {
+      'id': 3,
+      'resource_uri': '/braintree/mozilla/paymethod/3/',
+      'truncated_id': '0000',
+      'type_name': 'Maestro',
+  }];
+
+  beforeEach(function() {
+    this.onCardChange = sinon.stub();
+    this.CardDropDown = TestUtils.renderIntoDocument(
+      <CardDropDown cards={cardListData} onCardChange={this.onCardChange} />
+    );
+    sinon.spy(this.CardDropDown, 'setState');
+  });
+
+  afterEach(function() {
+    this.CardDropDown.setState.restore();
+  });
+
+  it('has expected content when card is selected', function() {
+    var event = {
+      target: {
+        value: '/braintree/mozilla/paymethod/3/',
+        selectedIndex: 3, // This is 3 because of the default option.
+        options: helpers.findAllNodesByTag(this.CardDropDown, 'option'),
+      },
+    };
+    this.CardDropDown.handleChange(event);
+    var content = helpers.findByClass(this.CardDropDown, 'content');
+    assert.include(findDOMNode(content).innerHTML, 'maestro');
+    assert.include(findDOMNode(content).innerHTML, '0000');
+  });
+
+  it('adds card-icon when card is selected', function() {
+    var event = {
+      target: {
+        value: '/braintree/mozilla/paymethod/1/',
+        selectedIndex: 1, // This is 1 because of the default option.
+        options: helpers.findAllNodesByTag(this.CardDropDown, 'option'),
+      },
+    };
+    this.CardDropDown.handleChange(event);
+    var cardIcon = helpers.findByClass(this.CardDropDown, 'card-icon');
+    assert.include(
+      findDOMNode(cardIcon).className.split(' '), 'cctype-mastercard');
+  });
+
+  it('updates internal state when card is selected', function() {
+    var event = {
+      target: {
+        value: '/braintree/mozilla/paymethod/2/',
+        selectedIndex: 2, // This is 2 because of the default option.
+        options: helpers.findAllNodesByTag(this.CardDropDown, 'option'),
+      },
+    };
+    this.CardDropDown.handleChange(event);
+    assert.ok(this.CardDropDown.setState.calledWith({
+      selectedText: ' ●●●● ●●●● ●●●● 1111',
+      selectedCardType: 'visa',
+    }), 'setState should be called');
+  });
+
+  it('calls onCardChange prop when card is selected', function() {
+    var event = {
+      target: {
+        value: '/braintree/mozilla/paymethod/2/',
+        selectedIndex: 2, // This is 2 because of the default option.
+        options: helpers.findAllNodesByTag(this.CardDropDown, 'option'),
+      },
+    };
+    this.CardDropDown.handleChange(event);
+    assert.ok(this.onCardChange.calledWith(event),
+              'onCardChange prop should be called');
+  });
+
+  it('adds active class when focused', function() {
+    this.CardDropDown.handleFocus();
+    var wrapper = findDOMNode(this.CardDropDown);
+    assert.include(wrapper.className.split(' '), 'active');
+  });
+
+  it('removes active class when blurred', function() {
+    this.CardDropDown.handleFocus();
+    this.CardDropDown.handleBlur();
+    var wrapper = findDOMNode(this.CardDropDown);
+    assert.notInclude(wrapper.className.split(' '), 'active');
+  });
+
+});

--- a/tests/views/test.pay-methods.jsx
+++ b/tests/views/test.pay-methods.jsx
@@ -28,13 +28,8 @@ describe('PayMethods', function() {
     );
   });
 
-  it('should have a visa card present', function() {
-    var content = helpers.findByClass(this.PayMethods, 'cctype-visa');
-    assert.ok(TestUtils.isDOMComponent(content));
-  });
-
-  it('should have an amex card present', function() {
-    var content = helpers.findByClass(this.PayMethods, 'cctype-amex');
+  it('should have a card dropdown', function() {
+    var content = helpers.findByClass(this.PayMethods, 'proxy-select');
     assert.ok(TestUtils.isDOMComponent(content));
   });
 


### PR DESCRIPTION
This is the drop-down component in React that follows the mocked-up version.
It manages it's own internal state. Values are passed up to parents via passing in a onCardChange prop. This way the parent can get notified of changes if it wants to and can also maintain state this way like it does for the card choice.

Dealing with a default selection will be a todo. Can work on that when we have the card default api sorted. We'll probably want to have the 'Please select' default option removed for that if we're going to keep it for this part of the UI.

Adding this to the Payment methods view is mostly a strawman so I can use it as a discussion point with Bram. Reversing this back should be easy though so it's not a big deal if we want to go back to a card list here.

![http___pay_webpack_8080_webpack-dev-server_management_html_access_token_2434814ed1502d9d3d1d5d7eb3f0280f75b99f00094cc4645b00cb008a7a5f30_is_not_available](https://cloud.githubusercontent.com/assets/1514/9117805/741a47de-3c64-11e5-94f6-618efac1b972.png)