### PR TITLE
Add signout link and styles (fixes #319)

### DIFF
--- a/public/js/views/management.jsx
+++ b/public/js/views/management.jsx
@@ -81,19 +81,26 @@ export default class Management extends Component {
   }
 
   renderNav = () => {
-     var nav = [];
-     for (var i = 0; i < navData.length; i += 1) {
-       var navItem = navData[i];
-       var isActive = this.props.tab === navItem.className;
-       var classes = cx('nav', navItem.className, {'active': isActive});
-       nav.push((
-         <li className={classes} key={navItem.className}>
-           <a href="#" onClick={this.props[navItem.action]}>
-             {navItem.text}</a>
-         </li>
-       ));
-     }
-     return <ul>{nav}</ul>;
+    var nav = [];
+    for (var i = 0; i < navData.length; i += 1) {
+      var navItem = navData[i];
+      var isActive = this.props.tab === navItem.className;
+      var classes = cx('nav', navItem.className, {'active': isActive});
+      nav.push((
+        <li className={classes} key={navItem.className}>
+          <a href="#" onClick={this.props[navItem.action]}>
+            {navItem.text}</a>
+        </li>
+      ));
+    }
+
+    nav.push((
+      <li className="signout">
+        <a href="#" onClick={this.userSignOut}>{gettext('Sign Out')}</a>
+      </li>
+    ));
+
+    return <ul>{nav}</ul>;
   }
 
   render() {

--- a/public/scss/_management.scss
+++ b/public/scss/_management.scss
@@ -166,8 +166,29 @@
         a:hover {
             background: $hover-grey;
             color: #fff;
-
         }
 
+        .signout {
+            bottom: 15px;
+            left: 15px;
+            position: absolute;
+            right: 15px;
+
+            a:link {
+                border-radius: 2px;
+                border: 1px solid $hover-grey;
+                padding: 0.5em;
+                text-align: center;
+                transition: all 0.3s;
+
+                &:focus,
+                &:hover,
+                &:active {
+                    color: #fff;
+                    background: none;
+                    border: 1px solid $ship-grey;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This adds the styling for the sign-out link. 

It's hooked up to the pre-existing signout action but it needs more work to clear the views and kick-off the login.


![my_account](https://cloud.githubusercontent.com/assets/1514/9207828/eef43f26-4067-11e5-9952-b02a05349e7e.png)
