### PR TITLE
Update subs look and feel

### DIFF
--- a/public/js/apps/management/app.jsx
+++ b/public/js/apps/management/app.jsx
@@ -109,6 +109,7 @@ export default class ManagementApp extends Component {
       children.push((
         <Subscriptions
           {...boundSubscriptionActions}
+          payMethods={connector.user.payMethods}
           userSubscriptions={connector.user.subscriptions}
         />
       ));

--- a/public/js/components/pay-method-drop-down.jsx
+++ b/public/js/components/pay-method-drop-down.jsx
@@ -20,12 +20,16 @@ export default class PayMethodDropDown extends Component {
         type_name: PropTypes.string,
       })
     ).isRequired,
+    selectId: PropTypes.string,
+    selectNameAttr: PropTypes.string,
     selectedPayMethodResource: PropTypes.string,
     showDefaultOption: PropTypes.bool,
   }
 
   static defaultProps = {
+    selectId: null,
     showDefaultOption: true,
+    selectNameAttr: 'pay-method',
   }
 
   constructor(props) {
@@ -151,10 +155,12 @@ export default class PayMethodDropDown extends Component {
           {this.state.selectedText}
         </span>
         <select
+          id={this.props.selectId}
           onBlur={this.handleBlur}
           onChange={this.handleChange}
           onFocus={this.handleFocus}
-          onKeyUp={this.handleChange}>
+          onKeyUp={this.handleChange}
+          name={this.props.selectNameAttr}>
           {payMethodOptions}
         </select>
       </div>

--- a/public/js/components/subscription-list.jsx
+++ b/public/js/components/subscription-list.jsx
@@ -8,6 +8,7 @@ import Subscription from 'components/subscription';
 export default class SubscriptionList extends Component {
 
   static propTypes = {
+    payMethods: PropTypes.array,
     subscriptions: PropTypes.array,
   }
 
@@ -26,7 +27,8 @@ export default class SubscriptionList extends Component {
       this.props.subscriptions.forEach((data) => {
         subs.push(
           <li key={data.id}>
-            <Subscription {...data}/>
+            <Subscription {...data}
+              payMethods={this.props.payMethods} />
           </li>
         );
       });

--- a/public/js/components/subscription.jsx
+++ b/public/js/components/subscription.jsx
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 
+import PayMethodDropDown from 'components/pay-method-drop-down';
 import { gettext } from 'utils';
 import * as products from 'products';
 
@@ -7,9 +8,18 @@ import * as products from 'products';
 export default class Subscription extends Component {
 
   static propTypes = {
+    paymethod: PropTypes.string.isRequired,
+    payMethods: PropTypes.array.isRequired,
     seller_product: PropTypes.shape({
       public_id: PropTypes.string,
     }).isRequired,
+    showNav: PropTypes.bool,
+    showNextPayment: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    showNav: true,
+    showNextPayment: true,
   }
 
   render() {
@@ -18,22 +28,29 @@ export default class Subscription extends Component {
     return (
       <div className="subscription">
         <div className="product">
-          <img alt="" src={productData.img}/>
-          <h2 className="seller">{productData.seller.name.en}</h2>
-          <p className="description">{productData.description.en}</p>
-        </div>
-        <div className="price">
-          <div>{productData.price.en}</div>
-          <div>{gettext('per month')}</div>
-        </div>
-        <nav>
-          <div className="change-pay-account">
-            <a href="#">{gettext('Change payment account')}</a>
+          <img alt="" src={productData.img} width="50" />
+          <div className="meta">
+            <h2 className="seller">{productData.seller.name.en}</h2>
+            <p className="description">{productData.description.en}</p>
+            <span className="price">
+              {gettext('Monthly price')} {productData.price.en}</span>
+            {this.props.showNextPayment ?
+              <span className="next-payment">
+                {gettext('Next payment')} PLACEHOLDER</span> : null}
           </div>
-          <div className="cancel">
-            <a href="#">{gettext('Cancel subscription')}</a>
-          </div>
-        </nav>
+        </div>
+        {this.props.showNav ?
+        <div className="actions">
+          <label className="vh"
+            htmlFor="pm">{gettext('Change payment account')}</label>
+          <PayMethodDropDown
+            payMethods={this.props.payMethods}
+            selectId="pm"
+            selectedPayMethodResource={this.props.paymethod}
+            showDefaultOption={false}
+          />
+          <a className="cancel" href="#">{gettext('Cancel subscription')}</a>
+        </div> : null}
       </div>
     );
   }

--- a/public/js/components/subscription.jsx
+++ b/public/js/components/subscription.jsx
@@ -28,7 +28,7 @@ export default class Subscription extends Component {
     return (
       <div className="subscription">
         <div className="product">
-          <img alt="" src={productData.img} width="50" />
+          <img alt="" src={productData.img} />
           <div className="meta">
             <h2 className="seller">{productData.seller.name.en}</h2>
             <p className="description">{productData.description.en}</p>

--- a/public/js/views/management/subscriptions.jsx
+++ b/public/js/views/management/subscriptions.jsx
@@ -8,6 +8,7 @@ export default class Subscriptions extends Component {
 
   static propTypes = {
     getUserSubscriptions: PropTypes.func.isRequired,
+    payMethods: PropTypes.array.isRequired,
     userSubscriptions: PropTypes.array.isRequired,
   };
 
@@ -22,6 +23,7 @@ export default class Subscriptions extends Component {
       <div className="subscriptions">
         <h1>{gettext('Subscriptions')}</h1>
         <SubscriptionList
+          payMethods={this.props.payMethods}
           subscriptions={this.props.userSubscriptions}
         />
       </div>

--- a/public/scss/_pay-method-drop-down.scss
+++ b/public/scss/_pay-method-drop-down.scss
@@ -3,7 +3,6 @@
   background: #fff;
   border: 1px solid #ccc;
   border-radius: 4px;
-  display: inline-block;
   font-size: $medium-font;
   margin-bottom: 1em;
   padding: 0.5em 2em 0.5em 0.5em;

--- a/public/scss/_subscriptions.scss
+++ b/public/scss/_subscriptions.scss
@@ -1,7 +1,10 @@
 .subscription-list {
     margin: 0;
-    max-width: 600px;
     padding: 0;
+
+    .small {
+        max-width: 300px;
+    }
 
     li {
         list-style-type: none;
@@ -17,49 +20,48 @@
 }
 
 .subscription {
+    overflow: hidden;
 
     .product {
-        float: left;
+        max-width: 50%;
 
         img {
             display: block;
-            width: 50px;
             float: left;
-            margin-right: 10px;
+            margin-right: 20px;
+            width: 50px;
+        }
+
+        .meta {
+            float: left;
+            width: calc(100% - 70px);
         }
 
         .seller {
-            padding: 0;
-            margin: 0 0 0.1em 0;
             font-weight: normal;
-            float: left;
-            white-space: nowrap;
+            margin: 0 0 0.1em 0;
             overflow: hidden;
+            padding: 0;
             text-overflow: ellipsis;
+            white-space: nowrap;
         }
 
         .description {
+            margin: 0 0 1em;
             text-align: left;
         }
+
+        .next-payment,
+        .price {
+            border-top: 1px solid $heading-border;
+            display: block;
+            padding: 0.5em 0;
+        }
     }
 
-    .price {
+    .actions,
+    .cancel,
+    .change-pay-account {
         float: right;
-    }
-
-    nav {
-        clear: both;
-        .cancel {
-            float: left;
-        }
-        .change-pay-account {
-            float: right;
-        }
-    }
-
-    &:after {
-        content: "";
-        display: table;
-        clear: both;
     }
 }

--- a/public/scss/common.scss
+++ b/public/scss/common.scss
@@ -11,7 +11,6 @@
 @import '_pay-method-list';
 @import '_pay-method-drop-down';
 @import '_pay-method-sprite';
-@import '_product';
 @import '_spinner';
 @import '_tooltip';
 @import '_typography';

--- a/public/scss/transaction.scss
+++ b/public/scss/transaction.scss
@@ -1,5 +1,6 @@
 @import 'inc/vars';
 @import 'inc/mixins';
 
+@import '_product';
 @import '_complete-payment';
 @import '_transaction.scss';


### PR DESCRIPTION
<img  alt="mozilla_firefox" src="https://cloud.githubusercontent.com/assets/1514/9252266/661fb7fc-41cf-11e5-81a7-6f8c10385455.png">

This is mainly a style + markup change to get the subs closer to the mocks. Still nothing is hooked up but the look and feel is closer. 

Note:  There's almost certainly more cleanup needed and the mobile CSS will come later. But at least the styles are closer for another pass at doing the action hookup for subs updates.

I've done this now because I needed to know what markup I'll be dealing with in order to deal with the pay method deletion which displays a subs list in some cases.