### PR TITLE
localize product name

### DIFF
--- a/public/js/utils.jsx
+++ b/public/js/utils.jsx
@@ -17,6 +17,23 @@ export function defaults(object, opt) {
   return object;
 }
 
+/**
+* Similar to getText, but works on a product JSON object returned by
+* the payments configuration so we can figure out the best data to show.
+*
+* This loops through each language in navigator.languages until it finds
+* a match, if not it falls back to en.
+*
+* @param {object} config - the value from payment-config
+*/
+
+export function configGetText(config, nav=navigator) {
+  var result = null;
+  var languages = nav.languages || new Array(nav.language || nav.userLanguage);
+  languages.some(value => result = config[value]);
+  return result || config.en;
+}
+
 
 export function isDisabled(domNode) {
   // Links dont' have disabled attrs so here we're checking

--- a/public/js/views/management/history.jsx
+++ b/public/js/views/management/history.jsx
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import JsonTable from 'react-json-table';
 
-import { gettext, setTitle } from 'utils';
+import { configGetText, gettext, setTitle } from 'utils';
 import * as products from 'products';
 import Spinner from 'components/spinner';
 
@@ -54,9 +54,10 @@ export default class History extends Component {
           </select>
         ),
         cell: (item) => (
-          // TODO: get localized seller name, not just English.
-          // https://github.com/mozilla/payments-ui/issues/307
-          products.get(item.transaction.seller_product.public_id).seller.name.en
+          configGetText(
+            products.get(
+              item.transaction.seller_product.public_id
+            ).seller.name)
         ),
       },
       {

--- a/tests/test.utils.jsx
+++ b/tests/test.utils.jsx
@@ -87,3 +87,31 @@ describe('utils.setTitle', function() {
     });
 
 });
+
+
+describe('utils.configGetText', function() {
+
+  it('should fallback', function() {
+    assert.equal(
+      utils.configGetText({'en': 'hello'}, {'languages': ['fr']}),
+      'hello'
+    );
+  });
+
+  it('should go through choice', function() {
+    assert.equal(
+      utils.configGetText(
+        {'fr': 'bonjour', 'es': 'hola'},
+        {'languages': ['de', 'fr', 'es']}),
+      'bonjour'
+    );
+  });
+
+  it('should cope with missing navigator.languages', function() {
+    assert.equal(
+      utils.configGetText({'fr': 'bonjour'}, {'language': 'fr'}),
+      'bonjour'
+    );
+  });
+
+});


### PR DESCRIPTION
* not sure how we are doing front end localisation, but a pull request is a good way to find out...
* provides a generic configGetText that can work on any localised object in payments-configuration
* would be easier if it was a JS module, i guess? :wink: 
* fixes #307 