### PR TITLE
Re-style the sign-out view (#334)

### DIFF
--- a/public/js/views/management.jsx
+++ b/public/js/views/management.jsx
@@ -63,27 +63,25 @@ export default class Management extends Component {
   renderNav = () => {
     var nav = [];
 
-    if (this.props.user.signedIn) {
-      for (var i = 0; i < navData.length; i += 1) {
-        var navItem = navData[i];
-        var isActive = this.props.tab === navItem.className;
-        var classes = cx('nav', navItem.className, {'active': isActive});
-        nav.push((
-          <li className={classes} key={navItem.className}>
-            <a href="#" onClick={this.props[navItem.action]}>
-              {navItem.text}</a>
-          </li>
-        ));
-      }
-
+    for (var i = 0; i < navData.length; i += 1) {
+      var navItem = navData[i];
+      var isActive = this.props.tab === navItem.className;
+      var classes = cx('nav', navItem.className, {'active': isActive});
       nav.push((
-        <li className="signout">
-          <a id="show-sign-out" href="#" onClick={this.showSignOut}>
-            {gettext('Sign Out')}
-          </a>
+        <li className={classes} key={navItem.className}>
+          <a href="#" onClick={this.props[navItem.action]}>
+            {navItem.text}</a>
         </li>
       ));
     }
+
+    nav.push((
+      <li className="signout">
+        <a id="show-sign-out" href="#" onClick={this.showSignOut}>
+          {gettext('Sign Out')}
+        </a>
+      </li>
+    ));
 
     return <ul>{nav}</ul>;
   }
@@ -91,13 +89,21 @@ export default class Management extends Component {
   render() {
     var props = this.props;
 
-    return (
-      <div>
-        <nav className="sidebar">
-          {this.renderNav()}
-        </nav>
-        <main className="content">{props.children}</main>
-      </div>
-    );
+    if (!this.props.user.signedIn) {
+      return (
+        <div>
+          <main className="content no-sidebar">{props.children}</main>
+        </div>
+      );
+    } else {
+      return (
+        <div>
+          <nav className="sidebar">
+            {this.renderNav()}
+          </nav>
+          <main className="content">{props.children}</main>
+        </div>
+      );
+    }
   }
 }

--- a/public/js/views/shared/sign-out.jsx
+++ b/public/js/views/shared/sign-out.jsx
@@ -31,12 +31,13 @@ export default class SignOut extends Component {
       return <Spinner text={gettext('Signing out')}/>;
     } else {
       return (
-        <div>
-          <p>{gettext('You are now signed out.')}</p>
+        <div className="signed-out">
           <p>
             <a className="button quiet" href="#"
               onClick={this.handleShowSignIn}>{gettext('Sign In')}</a>
           </p>
+          <p>{gettext('Sign in to add and remove payment methods, ' +
+                      'view receipts, and manage subscriptions.')}</p>
         </div>
       );
     }

--- a/public/scss/_management.scss
+++ b/public/scss/_management.scss
@@ -96,6 +96,11 @@
       margin: 0 0 0 200px;
       width: auto;
       max-width: 800px;
+
+      &.no-sidebar {
+          margin: 0 auto;
+          text-align: center;
+      }
     }
 
     .sidebar {

--- a/public/scss/_signed-out.scss
+++ b/public/scss/_signed-out.scss
@@ -1,0 +1,15 @@
+.management .signed-out {
+    width: 100%;
+    margin-top: 26%;
+
+    p {
+        width: 220px;
+        margin: 0 auto 1em auto;
+    }
+
+    .button.quiet {
+        background-color: transparent;
+        width: 100%;
+        margin-bottom: 0;
+    }
+}

--- a/public/scss/management.scss
+++ b/public/scss/management.scss
@@ -5,5 +5,6 @@
 @import '_subscriptions';
 @import '_mgmt-nav-sprite.scss';
 @import '_json-table';
+@import '_signed-out';
 @import 'lib/tabzilla';
 @import '_management';


### PR DESCRIPTION
NOTE: there is some glitch in my screencast converter where you see a ghost of a sidebar during the sign-in spinner. This does not appear in reality.

![sign-out mov](https://cloud.githubusercontent.com/assets/55398/9316502/06fee3cc-44fb-11e5-8cc5-a9fd626cafff.gif)


Supports https://github.com/mozilla/payments-ui/issues/334