### PR TITLE
Rename grunt tasks to be more descriptive (fixes #361)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,12 +38,29 @@ module.exports = function(grunt) {
 
   grunt.registerTask('build', ['clean:dist', 'sass', 'webpack']);
 
-  grunt.registerTask('serve',
+  // The dev server used for live reloading in the browser.
+  grunt.registerTask('serve', 'Dev server with webpack hot module reloading',
     ['clean:dist', 'sass:dev', 'webpack-dev-server:start', 'watch:sass']);
-  grunt.registerTask('start',
-    ['clean:dist', 'sass:dev', 'webpack:dev', 'watch:sass']);
-  grunt.registerTask('start-email',
+  // Used to serve email CSS.
+  grunt.registerTask('watch-email',
     ['clean:dist', 'sass:email', 'webpack:dev', 'watch:sassemail']);
+  // Regular grunt server, used when running inside the payments-env docker.
+  grunt.registerTask('watch-static',
+    ['clean:dist', 'sass:dev', 'webpack:dev', 'watch:sass']);
+  // Legacy tasks still used by payments-env, see:
+  // https://github.com/mozilla/payments-ui/issues/361
+  grunt.registerTask('start', 'Deprecated; use `watch-static` instead',
+                     function() {
+    grunt.log.writeln(
+      '"grunt start" is deprecated; use `grunt watch-static` instead');
+    grunt.task.run('watch-static');
+  });
+  grunt.registerTask('start-email', 'Deprecated; use `watch-email` instead',
+                     function() {
+    grunt.log.writeln(
+      '"grunt start-email" is deprecated; use `grunt watch-email` instead');
+    grunt.task.run('watch-email');
+  });
 
   grunt.registerTask('test', ['karma:run', 'eslint', 'csslint:lax']);
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,20 @@
 This project comprises all styles, behaviour and interfaces for
 [mozilla/payments](https://github.com/mozilla/payments).
 
+
+## Grunt tasks
+
+Run tasks with `grunt` e.g. `grunt watch-static` or `grunt serve`.
+
+| Task name       | Description |
+| ------------ | --------------- |
+| build  | build all CSS/JS files for deployment |
+| serve  | watch CSS/JS for changes; serves static files via `webpack` dev server to enable [hot module reloading](http://webpack.github.io/docs/hot-module-replacement-with-webpack.html) |
+| test | run tests locally |
+| test-sauce | run full Sauce Labs test suite |
+| watch-email | watch email-specific static files for changes; updates CSS/JS on change |
+| watch-static | watch files for changes; updates CSS/JS on change |
+
 ## Developers
 
 ### Email Styles
@@ -18,7 +32,7 @@ This project comprises all styles, behaviour and interfaces for
 To get the right paths for the email CSS and rebuild files as they change run:
 
 ```
-DEV=1 grunt start-email
+DEV=1 grunt watch-email
 ```
 
 ### Dependency installation and updates
@@ -55,7 +69,7 @@ cases will be rare.
 
 If you're using [payments-env][payments-env]
 to run the complete payments system then you'll want to use
-`grunt start` on your host to watch for file changes.
+`grunt watch-static` on your host to watch for file changes.
 In other words, start docker to run all the things but keep a shell open
 on the host machine just to compile static assets for the docker VM to serve.
 


### PR DESCRIPTION
Old tasks names kept around for now, until we update payments-env. (Assuming this is an okay change.)

These names make more sense to me, not sure what others think.

Closes #361.