### PR TITLE
Add email field when required (fixes #358)

### DIFF
--- a/public/js/components/card-input.jsx
+++ b/public/js/components/card-input.jsx
@@ -98,14 +98,23 @@ export default class CardInput extends Component {
                       errorModifier={this.props.errorModifier} /> : null }
         { showCardIcon ?
           <PayMethodIcon payMethodType={this.props.cardType} /> : null }
-        <MaskedInput
-          {...this.props.attrs}
-          id={this.props.id}
-          className={this.props.id + '-input'}
-          onChange={this.props.onChangeHandler}
-          pattern={pattern}
-          placeholder={placeholder}
-        />
+        {pattern ?
+          <MaskedInput
+            {...this.props.attrs}
+            id={this.props.id}
+            className={this.props.id + '-input'}
+            onChange={this.props.onChangeHandler}
+            pattern={pattern}
+            placeholder={placeholder}
+          /> :
+          <input
+            {...this.props.attrs}
+            id={this.props.id}
+            className={this.props.id + '-input'}
+            onChange={this.props.onChangeHandler}
+            placeholder={placeholder}
+          />
+        }
       </label>
     );
   }

--- a/public/js/utils.jsx
+++ b/public/js/utils.jsx
@@ -101,3 +101,60 @@ export function getPayMethodFromUri(payMethods, payMethodUri) {
   }
   return matches.length ? matches[0] : null;
 }
+
+
+export function isValidEmail(email) {
+  if (typeof email !== 'string') {
+    return false;
+  }
+
+  var parts = email.split('@');
+  var localLength = parts[0] && parts[0].length;
+  var domainLength = parts[1] && parts[1].length;
+
+  // Original regexp from:
+  //  http://blog.gerv.net/2011/05/html5_email_address_regexp/
+  // Modified to remove the length checks, which are done later.
+  // IETF spec: http://tools.ietf.org/html/rfc5321#section-4.5.3.1.1
+  // NOTE: this does *NOT* allow internationalized domain names.
+  /* eslint-disable max-len */
+  return (/^[\w.!#$%&'*+\-\/=?\^`{|}~]+@[a-z\d][a-z\d\-]*(?:\.[a-z\d][a-z\d\-]*)*$/i).test(email) &&
+  /* eslint-enable */
+    // total email allowed to be 254 bytes long
+    // see http://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690
+    email.length <= 254 &&
+    // local side only allowed to be 64 bytes long
+    localLength >= 1 && localLength <= 64 &&
+    // domain side allowed to be up to 255 bytes long which
+    // doesn't make much sense unless the local side has 0 length;
+    domainLength >= 1 && domainLength <= 255;
+}
+
+
+export function validateEmailAsYouType(email) {
+  var invalidEmail = {
+    isPotentiallyValid: false,
+    isValid: false,
+  };
+  if (typeof email !== 'string') {
+    return invalidEmail;
+  }
+  var parts = email.split('@');
+  if (parts.length === 2 && parts[0] && parts[1]) {
+    if (isValidEmail(email)) {
+      return {
+        isPotentiallyValid: true,
+        isValid: true,
+      };
+    } else {
+      return invalidEmail;
+    }
+  } else if (parts.length > 2) {
+    return invalidEmail;
+  } else {
+    return {
+      isPotentiallyValid: true,
+      isValid: false,
+    };
+  }
+}

--- a/public/js/views/transaction/product-pay.jsx
+++ b/public/js/views/transaction/product-pay.jsx
@@ -23,15 +23,20 @@ export default class ProductPay extends Component {
     tracking.setPage('/product-pay');
   }
 
-  handleCardSubmit(creditCard) {
+  handleCardSubmit(creditCard, {email} = {}) {
     console.log('submitting credit card to sign up for subscription',
                 this.props.productId);
-    this.props.processPayment({
+    var data = {
       productId: this.props.productId,
       creditCard: creditCard,
       braintreeToken: this.props.braintreeToken,
       userDefinedAmount: this.props.userDefinedAmount,
-    });
+    };
+    if (email) {
+      console.log('Card submission included an email address');
+      data.email = email;
+    }
+    this.props.processPayment(data);
   }
 
   render() {
@@ -39,6 +44,7 @@ export default class ProductPay extends Component {
     var submitPrompt;
     if (product.seller.kind === 'donations') {
       submitPrompt = gettext('Donate now');
+      var emailFieldRequired = product.user_identification === 'email';
     } else {
       // TODO: also handle non-recurring, non-donations here.
       submitPrompt = gettext('Subscribe');
@@ -51,11 +57,12 @@ export default class ProductPay extends Component {
           userDefinedAmount={this.props.userDefinedAmount}
         />
         <CardForm
-          submissionErrors={this.props.cardSubmissionErrors}
-          submitPrompt={submitPrompt}
+          emailFieldRequired={emailFieldRequired}
           handleCardSubmit={(card) => this.handleCardSubmit(card)}
           id="braintree-form"
           method="post"
+          submissionErrors={this.props.cardSubmissionErrors}
+          submitPrompt={submitPrompt}
         />
       </div>
     );

--- a/tests/components/test.card-form.jsx
+++ b/tests/components/test.card-form.jsx
@@ -18,12 +18,13 @@ describe('Card Form', function() {
   ];
   var handleCardSubmit;
 
-  function mountView({errors=null} = {}) {
+  function mountView({errors=null, emailFieldRequired=false} = {}) {
     return TestUtils.renderIntoDocument(
       <CardForm
-        submissionErrors={errors}
+        emailFieldRequired={emailFieldRequired}
         handleCardSubmit={handleCardSubmit}
         id="something"
+        submissionErrors={errors}
       />
     );
   }
@@ -84,6 +85,20 @@ describe('Card Form', function() {
     assert.ok(TestUtils.isCompositeComponent(expirationError));
   });
 
+ it('shows an email error on invalid input', function() {
+    var view = mountView({emailFieldRequired: true});
+    view.handleChange({
+      target: {
+        value: 'foo@@@@@',
+        id: 'email',
+      },
+    });
+    var email = helpers.findByClass(view, 'email');
+    assert.include(email.props.className, 'invalid');
+    var emailError = helpers.findByClass(email, 'tooltip');
+    assert.ok(TestUtils.isCompositeComponent(emailError));
+  });
+
   it('shows a cvv message from error props', function() {
     var view = mountView({errors: helpers.cvvError});
     var cvv = helpers.findByClass(view, 'cvv');
@@ -124,4 +139,8 @@ describe('Card Form', function() {
     }
   });
 
+  it('should have an email field if the product requires it', function() {
+    var view = mountView({emailFieldRequired: true});
+    assert.ok(helpers.findByClass(view, 'email-input'));
+  });
 });

--- a/tests/test.utils.jsx
+++ b/tests/test.utils.jsx
@@ -120,3 +120,48 @@ describe('utils.configGetText', function() {
   });
 
 });
+
+
+describe('utils.isValidEmail', function() {
+
+  it('should be invalid as incomplete', function() {
+    assert.notOk(utils.isValidEmail('foo@'));
+  });
+
+  it('should be valid', function() {
+    assert.ok(utils.isValidEmail('foo@bar'));
+  });
+
+  it('should be invalid as ending in period', function() {
+    assert.notOk(utils.isValidEmail('foo@bar.'));
+  });
+
+});
+
+describe('utils.validateEmailAsYouType', function() {
+
+  it('should be potentially valid but not valid', function() {
+    var emailData = utils.validateEmailAsYouType('foo@');
+    assert.ok(emailData.isPotentiallyValid);
+    assert.notOk(emailData.isValid);
+  });
+
+  it('should be fully valid', function() {
+    var emailData = utils.validateEmailAsYouType('foo@bar.com');
+    assert.ok(emailData.isPotentiallyValid);
+    assert.ok(emailData.isValid);
+  });
+
+  it('should be invalid ending in a period', function() {
+    var emailData = utils.validateEmailAsYouType('foo@bar.');
+    assert.notOk(emailData.isPotentiallyValid);
+    assert.notOk(emailData.isValid);
+  });
+
+  it('should be invalid as too many @', function() {
+    var emailData = utils.validateEmailAsYouType('foo@@');
+    assert.notOk(emailData.isPotentiallyValid);
+    assert.notOk(emailData.isValid);
+  });
+
+});


### PR DESCRIPTION
This displays the email field in the flow when required and does the necessary client-side validation + feedback as you type.

If passes the email as far as https://github.com/mozilla/payments-ui/blob/master/public/js/actions/transaction.js#L66 after that it will need additional changes to pass it to the API.