### PR TITLE
Use dropdown on transaction flow (fixes #299)

### DIFF
--- a/public/js/components/pay-method-choice.jsx
+++ b/public/js/components/pay-method-choice.jsx
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 
 import PayMethodList from 'components/pay-method-list';
+import PayMethodDropDown from 'components/pay-method-drop-down';
 import SubmitButton from 'components/submit-button';
 
 import { gettext } from 'utils';
@@ -15,20 +16,32 @@ export default class PayMethodChoice extends Component {
     submitButtonCSSModifier: PropTypes.string.isRequired,
     submitButtonText: PropTypes.string.isRequired,
     submitHandler: PropTypes.func.isRequired,
+    useDropDown: PropTypes.bool,
   }
 
   static defaultProps = {
     cssModifier: null,
     submitButtonText: gettext('Submit'),
     submitButtonModifier: null,
+    useDropDown: false,
   }
 
   constructor(props) {
     super(props);
+
+    var payMethodUri = null;
+    if (this.props.useDropDown) {
+      // TODO: Once a default pay method is possible this will need
+      // to be updated.
+      payMethodUri = this.props.payMethods[0].resource_uri;
+    } else {
+      payMethodUri = this.props.payMethods.length === 1 ?
+        this.props.payMethods[0].resource_uri : null;
+    }
+
     this.state = {
       isSubmitting: false,
-      payMethod: (this.props.payMethods.length === 1 ?
-                  this.props.payMethods[0].resource_uri : null),
+      payMethod: payMethodUri,
     };
   }
 
@@ -53,10 +66,18 @@ export default class PayMethodChoice extends Component {
 
     return (
       <form id="pay-method-choice" onSubmit={this.handleSubmit}>
-        <PayMethodList
-          cssModifier={this.props.cssModifier}
-          payMethods={payMethodData}
-          onPayMethodChange={this.handlePayMethodChange} />
+        {this.props.useDropDown === true ?
+          <PayMethodDropDown
+           onPayMethodChange={this.handlePayMethodChange}
+           payMethods={payMethodData}
+           showDefaultOption={false}
+          /> :
+          <PayMethodList
+            cssModifier={this.props.cssModifier}
+            payMethods={payMethodData}
+            onPayMethodChange={this.handlePayMethodChange}
+          />
+        }
         <SubmitButton isDisabled={!formIsValid}
           cssModifier={this.props.submitButtonCSSModifier}
           showSpinner={this.state.isSubmitting}

--- a/public/js/views/transaction/product-pay-chooser.jsx
+++ b/public/js/views/transaction/product-pay-chooser.jsx
@@ -50,6 +50,7 @@ export default class ProductPayChooser extends Component {
           productId={this.props.productId}
           submitButtonText={submitPrompt}
           submitHandler={this.handleSubmit}
+          useDropDown={true}
         />
         <a className="add-card" href="#"
           onClick={this.props.payWithNewCard}>

--- a/public/scss/_pay-method-drop-down.scss
+++ b/public/scss/_pay-method-drop-down.scss
@@ -4,8 +4,8 @@
   border: 1px solid #ccc;
   border-radius: 4px;
   font-size: $medium-font;
-  margin-bottom: 1em;
-  padding: 0.5em 2em 0.5em 0.5em;
+  margin: 1em 0;
+  padding: 0.5em 1.35em 0.5em 0.5em;
   position: relative;
   width: 100%;
   max-width: 300px;

--- a/public/scss/_subscriptions.scss
+++ b/public/scss/_subscriptions.scss
@@ -47,6 +47,10 @@
 .subscription {
     overflow: hidden;
 
+    .proxy-select {
+        margin-top: 0;
+    }
+
     .product {
         max-width: 50%;
 

--- a/tests/components/test.pay-method-choice.jsx
+++ b/tests/components/test.pay-method-choice.jsx
@@ -6,49 +6,52 @@ import PayMethodChoice from 'components/pay-method-choice';
 import * as helpers from '../helpers';
 
 
-describe('Pay Method Choice', function() {
+const cards = [
+  'amex',
+  'discover',
+  'jcb',
+  'maestro',
+  'mastercard',
+  'visa',
+];
 
-  var cards = [
-    'amex',
-    'discover',
-    'jcb',
-    'maestro',
-    'mastercard',
-    'visa',
-  ];
+const payMethodData = [{
+    'id': 1,
+    'resource_uri': '/braintree/mozilla/paymethod/1/',
+    'truncated_id': '4444',
+    'type_name': 'MasterCard',
+  }, {
+    'id': 2,
+    'resource_uri': '/braintree/mozilla/paymethod/2/',
+    'truncated_id': '1111',
+    'type_name': 'Visa',
+  }, {
+    'id': 3,
+    'resource_uri': '/braintree/mozilla/paymethod/3/',
+    'truncated_id': '0000',
+    'type_name': 'Maestro',
+  }, {
+    'id': 4,
+    'resource_uri': '/braintree/mozilla/paymethod/4/',
+    'truncated_id': '0000',
+    'type_name': 'JCB',
+  }, {
+    'id': 5,
+    'resource_uri': '/braintree/mozilla/paymethod/5/',
+    'truncated_id': '0000',
+    'type_name': 'Discover',
+  }, {
+    'id': 6,
+    'resource_uri': '/braintree/mozilla/paymethod/6/',
+    'truncated_id': '8431',
+    'type_name': 'American-Express',
+  },
+];
 
-  var payMethodData = [{
-      'id': 1,
-      'resource_uri': '/braintree/mozilla/paymethod/1/',
-      'truncated_id': '4444',
-      'type_name': 'MasterCard',
-    }, {
-      'id': 2,
-      'resource_uri': '/braintree/mozilla/paymethod/2/',
-      'truncated_id': '1111',
-      'type_name': 'Visa',
-    }, {
-      'id': 3,
-      'resource_uri': '/braintree/mozilla/paymethod/3/',
-      'truncated_id': '0000',
-      'type_name': 'Maestro',
-    }, {
-      'id': 4,
-      'resource_uri': '/braintree/mozilla/paymethod/4/',
-      'truncated_id': '0000',
-      'type_name': 'JCB',
-    }, {
-      'id': 5,
-      'resource_uri': '/braintree/mozilla/paymethod/5/',
-      'truncated_id': '0000',
-      'type_name': 'Discover',
-    }, {
-      'id': 6,
-      'resource_uri': '/braintree/mozilla/paymethod/6/',
-      'truncated_id': '8431',
-      'type_name': 'American-Express',
-    },
-  ];
+const singlePayMethodData = [payMethodData[0]];
+
+
+describe('Pay Method Choice (List)', function() {
 
   beforeEach(function() {
     this.PayMethodChoice = TestUtils.renderIntoDocument(
@@ -71,10 +74,10 @@ describe('Pay Method Choice', function() {
   }
 
   cards.forEach(function(card) {
-    it('Displays each card type ' + card, testCardType(card));
+    it('displays each card type ' + card, testCardType(card));
   });
 
-  it('Checked prop is updated when card is selected', function() {
+  it('updates checked property when card is selected', function() {
     var event = {
       target: {
         value: '/braintree/mozilla/paymethod/5/',
@@ -82,11 +85,11 @@ describe('Pay Method Choice', function() {
     };
     this.PayMethodChoice.handlePayMethodChange(event);
     var input = TestUtils.scryRenderedDOMComponentsWithTag(
-        this.PayMethodChoice, 'input')[4];
+      this.PayMethodChoice, 'input')[4];
     assert.equal(input.props.checked, true);
   });
 
-  it('State is updated when card is selected', function() {
+  it('updates state when pay method is selected', function() {
     var event = {
       target: {
         value: 'whatevar',
@@ -98,12 +101,12 @@ describe('Pay Method Choice', function() {
     }), 'setState should be called');
   });
 
-  it('Has a disabled button when no card is selected', function() {
+  it('has a disabled button when no pay method is selected', function() {
     var submitButton = helpers.findByTag(this.PayMethodChoice, 'button');
     assert.notEqual(submitButton.getDOMNode().getAttribute('disabled'), null);
   });
 
-  it('has button enabled when selection is made', function() {
+  it('has the submit button enabled when selection is made', function() {
     var submitButton = helpers.findByTag(this.PayMethodChoice, 'button');
     var event = {
       target: {
@@ -123,29 +126,73 @@ describe('Pay Method Choice', function() {
 
 });
 
-describe('Single Card Choice', function() {
 
-    var payMethodData = [{
-        'id': 1,
-        'resource_uri': '/braintree/mozilla/paymethod/1/',
-        'truncated_id': '4444',
-        'type_name': 'MasterCard',
-       },
-     ];
+describe('Single Pay Method (List)', function() {
 
-    beforeEach(function() {
-      this.PayMethodChoice = TestUtils.renderIntoDocument(
-        <PayMethodChoice payMethods={payMethodData} />
-      );
-    });
+  beforeEach(function() {
+    this.PayMethodChoice = TestUtils.renderIntoDocument(
+      <PayMethodChoice payMethods={singlePayMethodData} />
+    );
+  });
 
-    it('Has the card selected when just one card', function() {
-        var input = helpers.findByTag(this.PayMethodChoice, 'input');
-        assert.equal(input.getDOMNode().getAttribute('checked'), '');
-    });
+  it('has the card selected with a single pay method', function() {
+    var input = helpers.findByTag(this.PayMethodChoice, 'input');
+    assert.equal(input.getDOMNode().getAttribute('checked'), '');
+  });
 
-    it('Has the submit button enabled when just one card', function() {
-      var submitButton = helpers.findByTag(this.PayMethodChoice, 'button');
-      assert.equal(submitButton.getDOMNode().getAttribute('disabled'), null);
-    });
+  it('has the submit button enabled with a single pay method', function() {
+    var submitButton = helpers.findByTag(this.PayMethodChoice, 'button');
+    assert.equal(submitButton.getDOMNode().getAttribute('disabled'), null);
+  });
+
+});
+
+
+describe('Pay Method Choice (DropDown)', function() {
+
+  beforeEach(function() {
+    this.PayMethodChoice = TestUtils.renderIntoDocument(
+      <PayMethodChoice
+        payMethods={payMethodData}
+        useDropDown={true}
+      />
+    );
+  });
+
+  it('displays a drop-down with 6 options', function() {
+    assert.equal(
+      helpers.findAllByTag(this.PayMethodChoice, 'select').length, 1);
+    assert.equal(helpers.findAllByTag(this.PayMethodChoice, 'option').length,
+                 payMethodData.length);
+  });
+
+  it('has a submit button enabled by default', function() {
+    var submitButton = helpers.findByTag(this.PayMethodChoice, 'button');
+    assert.equal(submitButton.getDOMNode().getAttribute('disabled'), null);
+  });
+
+});
+
+
+describe('Single Pay Method (DropDown)', function() {
+
+  beforeEach(function() {
+    this.PayMethodChoice = TestUtils.renderIntoDocument(
+      <PayMethodChoice
+        payMethods={singlePayMethodData}
+        useDropDown={true}
+      />
+    );
+  });
+
+  it('has selected the option when just one pay method', function() {
+    var option = helpers.findByTag(this.PayMethodChoice, 'select');
+    assert.equal(option.getDOMNode().options.selectedIndex, 0);
+  });
+
+  it('has the submit button enabled', function() {
+    var submitButton = helpers.findByTag(this.PayMethodChoice, 'button');
+    assert.equal(submitButton.getDOMNode().getAttribute('disabled'), null);
+  });
+
 });

--- a/tests/components/test.pay-method-icon.jsx
+++ b/tests/components/test.pay-method-icon.jsx
@@ -10,7 +10,7 @@ describe('Pay Method Icon', function() {
     'discover',
     'jcb',
     'maestro',
-    'masterpayMethod',
+    'mastercard',
     'visa',
   ];
 


### PR DESCRIPTION
For the payment choice form it's now a prop boolean option as to whether you get a dropdown or the list.

The transaction flow defaults to having this on. E.g:

<img width="303" alt="mozilla_payments" src="https://cloud.githubusercontent.com/assets/1514/9640504/df3516c0-51a9-11e5-8e19-202f6cb35de8.png">
