### PR TITLE
Show credit card entry errors in mgmt (fixes #426)

### DIFF
--- a/public/js/apps/management/app.jsx
+++ b/public/js/apps/management/app.jsx
@@ -112,6 +112,7 @@ export default class ManagementApp extends Component {
             {...boundMgmtActions}
             {...boundPayMethodActions}
             {...boundUserActions}
+            cardSubmissionErrors={management.cardSubmissionErrors}
             braintreeToken={user.braintreeToken}
           />
         ));

--- a/public/js/reducers/management.js
+++ b/public/js/reducers/management.js
@@ -5,6 +5,7 @@ export const initialMgmtState = {
   tab: null,
   view: null,
   viewData: {},
+  cardSubmissionErrors: null,
 };
 
 

--- a/tests/apps/test.management-app.jsx
+++ b/tests/apps/test.management-app.jsx
@@ -4,6 +4,8 @@ import { Provider } from 'react-redux';
 
 import { createReduxStore } from 'data-store';
 
+import * as actionTypes from 'constants/action-types';
+import * as mgmtActions from 'actions/management';
 import ManagementApp from 'apps/management/app';
 
 import * as helpers from '../helpers';
@@ -63,6 +65,27 @@ describe('management/app', function() {
     // Make sure it gets the access token.
     var signIn = mgmt.props.children[1];
     assert.equal(signIn.props.accessToken, token);
+
+  });
+
+  it('should pass in card submission errors', function() {
+    store.dispatch({
+      type: actionTypes.GOT_BRAINTREE_TOKEN,
+      braintreeToken: 'some-token',
+    });
+    store.dispatch(mgmtActions.showAddPayMethod());
+    var apiError = {error_response: 'some error'};
+    store.dispatch({
+      type: actionTypes.CREDIT_CARD_SUBMISSION_ERRORS,
+      apiErrorResult: apiError,
+    });
+    var view = mountView();
+
+    var mgmt = TestUtils.findRenderedComponentWithType(
+      view, FakeManagement
+    );
+    var addPayMethod = mgmt.props.children[1];
+    assert.equal(addPayMethod.props.cardSubmissionErrors, apiError);
 
   });
 

--- a/tests/reducers/test.management-reducer.js
+++ b/tests/reducers/test.management-reducer.js
@@ -36,6 +36,15 @@ describe('management reducer', () => {
     );
   });
 
+  it('stores card submission errors', () => {
+    var apiError = {error_response: 'invalid monkey name'};
+    var state = Object.assign({}, initialMgmtState, {
+      type: actionTypes.CREDIT_CARD_SUBMISSION_ERRORS,
+      cardSubmissionErrors: apiError,
+    });
+    assert.deepEqual(state.cardSubmissionErrors, apiError);
+  });
+
   it('preserves tab on error', () => {
     var existingState = Object.assign({}, initialMgmtState, {
       tab: 'pay-methods',


### PR DESCRIPTION
Fixes https://github.com/mozilla/payments-ui/issues/426

After the fix the screen looks like this:
<img width="551" alt="screenshot 2015-09-11 15 04 52" src="https://cloud.githubusercontent.com/assets/55398/9825601/fb6e290c-5899-11e5-83a4-43861e9a1476.png">

However, you still can't proceed because of https://github.com/mozilla/payments-ui/issues/420