### PR TITLE
chore(package): update mocha to version 2.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "load-grunt-tasks": "3.4.0",
     "lodash.defaults": "3.1.2",
     "lodash.merge": "3.3.2",
-    "mocha": "2.3.4",
+    "mocha": "2.4.2",
     "mozilla-payments-saucelabs-browsers": "0.0.1",
     "node-libs-browser": "0.5.3",
     "payment-icons": "0.0.6",


### PR DESCRIPTION
Update to get branch run against master.

Once travis has run a build re-running the tests only runs the tests against the build made at the time the pr was made. As a result changes to master since that point in time are not reflected in the re-run build.

Since the new version of karma should fix all the socket related forEach bugs we want to run this change against master.
